### PR TITLE
use wzrd.in

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,12 +2,12 @@ const envs = {
   production: {
     GITHUB_CLIENT_ID: '8d3a840b9412821160da',
     GATEKEEPER: 'https://esnextbin-gatekeeper.herokuapp.com/token',
-    BROWSERIFY_CDN: 'https://wzrd.now.sh'
+    BROWSERIFY_CDN: 'https://wzrd.in'
   },
   development: {
     GITHUB_CLIENT_ID: '8c4bcc76f39c83be7109',
     GATEKEEPER: 'http://localhost:9393/token',
-    BROWSERIFY_CDN: 'https://wzrd.now.sh'
+    BROWSERIFY_CDN: 'https://wzrd.in'
   }
 };
 


### PR DESCRIPTION
@voronianski now.sh is shutting down their old service that this wzrd instance was running on, so it can't be used anymore. I haven't touched wzrd.in in a while but it seems quite stable these days, so hopefully it is fine to use it for esnextbin again.